### PR TITLE
small typos in german translation

### DIFF
--- a/presentations/coaching/de.html
+++ b/presentations/coaching/de.html
@@ -68,9 +68,8 @@
     <div class="slide" id="material"><div>
       <section>
         <header>
-          <h2>Das Material</h2>
         </header>
-        <p>Wir glauben ernsthaft, dass die beste Art, Programmieren zu lernen, &mdash; oder jedes andere technische Fach &mdash; ein <strong>praktischer</strong>, <strong>erlebnisorientierter</strong> and <strong>pragmatischer</strong> Workshop ist, der Lernende in <strong>ihrer Geschwindigkeit</strong> bearbeiten. Unsere Materialien sind genau darauf ausgelegt.</p>
+        <p>Wir glauben ernsthaft, dass die beste Art, Programmieren zu lernen, &mdash; oder jedes andere technische Fach &mdash; ein <strong>praktischer</strong>, <strong>erlebnisorientierter</strong> and <strong>pragmatischer</strong> Workshop ist, den Lernende in <strong>ihrer Geschwindigkeit</strong> bearbeiten. Unsere Materialien sind genau darauf ausgelegt.</p>
         <p>Das sieht man auch darin, wie wir unsere Workshops vor Ort organisieren: Es gibt keinen Frontalunterricht. Jeder hat stattdessen seinen eigenen Arbeitsplatz, Es gibt keinen Lehrer an der Tafel und niemand trägt das Material für alle vor.</p>
       </section>
     </div></div>
@@ -83,12 +82,12 @@
         <p>
           <ul>
             <li>Manchmal scheint das Material unnötig vollgepackt, als ob es immer wieder das selbe sagt.</li>
-            <li>Sorge dich nicht, das ist Absicht!</li>
-            <li>Wir glaube an erforschendes Lernen (manchmal <em>the hard way</em> genannt)</li>
+            <li>Keine Sorge, das ist Absicht!</li>
+            <li>Wir glauben an erforschendes Lernen (manchmal <em>the hard way</em> genannt)</li>
             <li>Das umfasst, einen suboptimalen Ansatz zuerst zu vermitteln, damit sie <strong>selbst</strong> herausfinden, wie und warum es besser geht. Beispiel:
               <ul>
-                <li>Schreibe einen Ausdruck, den du fünfmal wiederholen magst zuerst fünfmal hintereinander.</li>
-                <li>Damit sie verstehen, wie mächtig und bequem Schleifen sind.</li>
+                <li>Schreibe einen Ausdruck, den du fünfmal wiederholen magst zuerst fünfmal hintereinander</li>
+                <li>damit sie dann verstehen, wie mächtig und bequem Schleifen sind.</li>
               </ul>
             </li>
           </ul>
@@ -104,12 +103,12 @@
         <p>&hellip; in dem Sinne, dass wir nicht vorn stehen und belehren.</p>
         <p>Coaches&hellip;
           <ul>
-            <li>Stehen an der Seite</li>
-            <li>Sind da, wenn sie gebraucht werden</li>
-            <li>Fokussieren sich auf die Lernenden</li>
-            <li>Fühlen sich in ihre (Un-)Zulänglichkeiten ein</li>
-            <li>Ermuntern Lernende durch positive Motivation voranzukommen</li>
-            <li>Stellen sicher, dass sie Spaß haben</li>
+            <li>stehen an der Seite</li>
+            <li>sind da, wenn sie gebraucht werden</li>
+            <li>fokussieren sich auf die Lernenden</li>
+            <li>fühlen sich in ihre (Un-)Zulänglichkeiten ein</li>
+            <li>ermuntern Lernende durch positive Motivation voranzukommen</li>
+            <li>stellen sicher, dass sie Spaß haben</li>
           </ul>
         </p>
       </section>
@@ -118,7 +117,7 @@
     <div class="slide" id="friendly_environment"><div>
       <section>
         <header>
-          <h2>Eine Freundliche Athmosphäre Erzeugen</h2>
+          <h2>Eine freundliche Athmosphäre erzeugen</h2>
           Atmosphäre
         </header>
         <p>
@@ -138,17 +137,17 @@
     <div class="slide" id="friendly_environment_2"><div>
       <section>
         <header>
-          <h2>Eine Freundliche Athmosphäre Erzeugen</h2>
+          <h2>Eine freundliche Athmosphäre erzeugen</h2>
           Ermutigung
         </header>
         <p>
           <ul>
-            <li>Nimm an, dass jeder, den du coachst kein Wissen aber unendliche Intelligenz besitzt</li>
-            <li>Benutze normale Sprache statt Slang</li>
-            <li>Finde heraus, ob der Lernende das verstanden hat, was du sagst</li>
+            <li>nimm an, dass jeder, den du coachst kein Wissen aber unendliche Intelligenz besitzt</li>
+            <li>benutze normale Sprache statt Slang</li>
+            <li>finde heraus, ob der Lernende das verstanden hat, was du sagst</li>
             <li>und erkläre es erneut anders, wenn das nicht der Fall ist</li>
-            <li>Ermutige Lernende, selbstständig herumzuspielen</li>
-            <li>Was immer sie machen, es ist großartig und wunderschön!</li>
+            <li>ermutige Lernende, selbstständig herumzuspielen</li>
+            <li>was immer sie machen, es ist großartig und wunderschön!</li>
           </ul>
         </p>
       </section>
@@ -164,7 +163,7 @@
           <ul>
             <li>Schau dich um, ob jemand anderes Probleme hat</li>
             <li>Sie könnten einfach Ansgt haben zu fragen</li>
-            <li>Komme manchmal vorbei und frage: „Hi, wie geht's?  Kann ich dir irgendwie helfen?“
+            <li>Komme manchmal vorbei und frage: „Hi, wie geht's? Kann ich dir irgendwie helfen?“
               <ul>
                   <li>Das ist ein mächtiges Werkzeug: Es hilft Schüchternen, verbindet und erhöht das Engagement.</li>
                   <li>Ein anderer Trick: Setze dich neben sie und sprecht über das, was sie tun.</li>
@@ -256,9 +255,9 @@
         </header>
         <p>
           <ul>
-            <li>Akzeptiere keine Lernenden, wenn sie sagen, dass sie zu <em>irgendwie</em> sind, um etwas zu tun: Antworte, dass sie es können.</li>
-            <li>Freue dich mit den Lernenden für ihre Errungenschaften, nimm dir die Zeit, dir diese zeigen zu lassen.</li>
-            <li>Wenn Leute vom Weg abkommen aber Spaß haben, ermutige sie, das zu tun.</li>
+            <li>Akzeptiere es nicht, wenn Lernende sagen, dass sie zu <em>irgendwie</em> sind, um etwas zu tun: Antworte, dass sie es können.</li>
+            <li>Freue dich mit den Lernenden über ihre Errungenschaften, nimm dir die Zeit, dir diese zeigen zu lassen.</li>
+            <li>Wenn Leute vom Weg abkommen aber Spaß haben, ermutige sie es weiter zu tun.</li>
             <li>Ermutige Lernende, ihre Ergebnisse anderen zu zeigen: lade sie zu Demos am Ende oder zum nächsten <a href="http://www.opentechschool.org/handbooks/learners_meetup.html" target="_blank">Learners Meetup</a> ein, um ihr Zeug zu zeigen. Sag es zweimal oder dreimal, was immer nötig ist.</li>
           </ul>
         </p>
@@ -286,7 +285,7 @@
             <li>Wir nutzen die Zeit nicht, um unsere Firmen/Jobs/uns zu bewerben</li>
             <li>Wir hacken nicht herum oder machen lächerlich (nichtmal PHP!)</li>
             <li>Wir <strong>debattieren nicht</strong>, welche Programmiersprache, Methode oder Werkzeuge „am besten“ sind</li>
-            <li>Wir fassen nicht Maus oder Tastatur an</li>
+            <li>Wir fassen nicht ihre Maus oder Tastatur an</li>
           </ul>
         </p>
       </section>


### PR DESCRIPTION
- Ausdruck, Groß/Kleinschreibung, Kommasetzung sollte insgesamt rund gemacht werden.
- german phrases, case sensitivity of headwords and commas should be made better